### PR TITLE
chore: make a few funcs hit 100% accuracy

### DIFF
--- a/.github/workflows/build-and-report.yml
+++ b/.github/workflows/build-and-report.yml
@@ -100,13 +100,15 @@ jobs:
         run: |
           reccmp-project detect --what original   --search-path cmr2bin
           reccmp-project detect --what recompiled --search-path build
-      - name: Summarize Accuracy
+
+      - name: Generate Accuracy Report
+        if: github.ref == 'refs/heads/main' # Only runs on main branch
         shell: bash
         run: |
           reccmp-reccmp --target CMR2 --html index.html --json CMR2PROGRESS/summary.json
 
-      - name: Compare Accuracy With Current main
-        if: github.ref != 'refs/heads/main' # Only runs on not the 'main' branch
+      - name: Compare Accuracy to main
+        if: github.ref != 'refs/heads/main' # Only runs on pull requests
         shell: bash
         env:
           RELEASE_URL: https://raw.githubusercontent.com/CMR2Decomp/CMR2Decomp/refs/heads/main/CMR2PROGRESS/

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ mono_crash.*
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
+[Bb]uild
 
 [Dd]ebug/x64/
 [Dd]ebugPublic/x64/

--- a/CMR2Decomp/RallyData.cpp
+++ b/CMR2Decomp/RallyData.cpp
@@ -1,7 +1,7 @@
 #include "RallyData.h"
 
 // GLOBAL: CMR2 0x0052f2ac
-int g_selectedRallyData = 0;
+unsigned int g_selectedRallyData = 0;
 
 // FUNCTION: CMR2 0x00406910
 unsigned int RallyDataCountryIndex(void) {

--- a/CMR2Decomp/RallyTiming.cpp
+++ b/CMR2Decomp/RallyTiming.cpp
@@ -7,25 +7,29 @@ char g_rallyOverallOrderDriverID[16];
 int g_rallyOverallTimesRaw[32];
 
 // FUNCTION: CMR2 0x0040d390
-int __stdcall RallyTiming_GetOverallPositionDriverID(int iPosition) {
+int __stdcall RallyTiming_GetOverallPositionDriverID(int iPosition)
+{
 	return g_rallyOverallOrderDriverID[iPosition];
 }
 
 // FUNCTION: CMR2 0x0040d3b0
-int RallyTiming_GetOverallTimeForPosition(int iPosition) {
+int RallyTiming_GetOverallTimeForPosition(int iPosition)
+{
 	int rawTime = g_rallyOverallTimesRaw[g_rallyOverallOrderDriverID[iPosition]];
 	return 2200;
 }
 
 // FUNCTION: CMR2 0x0040d100
-void RallyTiming_ResetOverallPlayerTimes(void) {
+void RallyTiming_ResetOverallPlayerTimes(void)
+{
 	int iVar1 = 0;
-	int* puVar2 = g_rallyOverallTimesRaw;
+	int *puVar2 = g_rallyOverallTimesRaw;
 
-	do {
+	do
+	{
 		*puVar2 = 0;
 		g_rallyOverallOrderDriverID[iVar1] = iVar1;
 		puVar2 += 1;
 		iVar1 += 1;
-	} while (puVar2 < (int*)(0x00533698));
+	} while (puVar2 < (int *)(0x00533698));
 }

--- a/CMR2Decomp/Stage.cpp
+++ b/CMR2Decomp/Stage.cpp
@@ -3,7 +3,6 @@
 // GLOBAL: CMR2 0x00542cac
 char g_stageSplitCount = 0;
 
-
 // FUNCTION: CMR2 0x004583c0
 int GetStageSplitCount(void)
 {

--- a/CMR2Decomp/StageTiming.cpp
+++ b/CMR2Decomp/StageTiming.cpp
@@ -6,7 +6,8 @@
 char g_stageSplitDriverIndices[10][16];
 
 // FUNCTION: CMR2 0x00455cf0
-int __stdcall StageTiming_GetTimeForPosition(int positionIx) {
+int __stdcall StageTiming_GetTimeForPosition(int positionIx)
+{
     int iSplitIx = GetStageSplitCount();
 
     /* This isn't the driver name, just the index in the lookup table. It looks like

--- a/CMR2Decomp/StageTiming.h
+++ b/CMR2Decomp/StageTiming.h
@@ -4,5 +4,3 @@
 int __stdcall StageTiming_GetTimeForPosition(int positionIx);
 
 #endif
-
-

--- a/CMR2Decomp/TimingUtils.cpp
+++ b/CMR2Decomp/TimingUtils.cpp
@@ -3,6 +3,7 @@
 #include <stdio.h>
 
 // FUNCTION: CMR2 0x004de170
-void __stdcall FormatCentisecondsAsMinSecMSec(int iTime, char* pcFormattedTime) {
+void __stdcall FormatCentisecondsAsMinSecMSec(int iTime, char *pcFormattedTime)
+{
 	sprintf(pcFormattedTime, g_minSecMSECFormatString, iTime / 6000, (iTime % 6000) / 100, iTime % 100);
 }

--- a/CMR2Decomp/TimingUtils.h
+++ b/CMR2Decomp/TimingUtils.h
@@ -1,8 +1,8 @@
 #ifndef _TIMING_UTILS_H
 #define _TIMING_UTILS_H
 
-const char* g_minSecMSECFormatString = "%02d:%02d.%02d";
+const char *g_minSecMSECFormatString = "%02d:%02d.%02d";
 
-void __stdcall FormatCentisecondsAsMinSecMSec(int iTime, char* pcFormattedTime);
+void __stdcall FormatCentisecondsAsMinSecMSec(int iTime, char *pcFormattedTime);
 
 #endif


### PR DESCRIPTION
- `RallyDataStageIndex` and `RallyDataState` are now classed as 100% accurate.
- Singular diff in `StageTiming_GetTimeForPosition` as its calling an offset instead of the function name?