### PR TITLE
Improve RallyTiming_ResetOverallPlayerTimes

### DIFF
--- a/CMR2Decomp/RallyTiming.cpp
+++ b/CMR2Decomp/RallyTiming.cpp
@@ -6,6 +6,9 @@ char g_rallyOverallOrderDriverID[16];
 // GLOBAL: CMR2 0x00533658
 int g_rallyOverallTimesRaw[16];
 
+// GLOBAL: CMR2 0x00533698
+const int *unk0x533698 = (int *)g_rallyOverallTimesRaw[0] + 16;
+
 // FUNCTION: CMR2 0x0040d390
 int __stdcall RallyTiming_GetOverallPositionDriverID(int iPosition)
 {
@@ -22,14 +25,13 @@ int RallyTiming_GetOverallTimeForPosition(int iPosition)
 // FUNCTION: CMR2 0x0040d100
 void RallyTiming_ResetOverallPlayerTimes(void)
 {
-	unsigned int ix = 0;
+	int ix = 0;
 	int *ptr = g_rallyOverallTimesRaw;
 
 	do
 	{
 		*ptr = 0;
 		g_rallyOverallOrderDriverID[ix] = ix;
-		ptr++;
 		ix++;
-	} while (ptr < (int *)(*(&g_rallyOverallTimesRaw + 1) - g_rallyOverallTimesRaw));
+	} while (++ptr < unk0x533698);
 }


### PR DESCRIPTION
Still not quite right but now at ~73% accuracy

```
---
+++
@@ -0x40d100,9 +0x401130,10 @@
	+mov edx, dword ptr [unk0x533698 (DATA)] (RallyTiming.cpp:27)
0x40d100	xor eax, eax
0x40d102	mov ecx, g_rallyOverallTimesRaw[0] (DATA)
0x40d107	mov dword ptr [ecx], 0 (RallyTiming.cpp:33)
0x40d10d	mov byte ptr [eax + g_rallyOverallOrderDriverID[0] (DATA)], al (RallyTiming.cpp:34)
0x40d113	add ecx, 4 (RallyTiming.cpp:36)
0x40d116	inc eax
0x40d117	-cmp ecx, unk0x533698 (DATA)
0x40d11d	-jl -0x18
	+cmp ecx, edx
	+jb -0x14
0x40d11f	ret (RallyTiming.cpp:37)
```