### PR TITLE
chore(ci): move accuracy reporting commits to pull requests

### DIFF
--- a/.github/workflows/build-and-report.yml
+++ b/.github/workflows/build-and-report.yml
@@ -20,25 +20,6 @@ jobs:
     name: Download original binary
     uses: ./.github/workflows/cmr2bin.yml
 
-  # build:
-  #   name: Compile Visual Studio project with MSBuild
-  #   needs: [fetch-deps]
-  #   runs-on: "windows-latest"
-  #   steps:
-  #     - uses: actions/checkout@main
-  #     - name: Build
-  #       shell: cmd
-  #       run: ${{ '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" && msbuild /p:Platform=x86' }}
-  #       working-directory: CMR2Decomp
-
-  #     - name: Upload Artifact
-  #       uses: actions/upload-artifact@main
-  #       with:
-  #         name: Win32
-  #         path: |
-  #           CMR2Decomp/Debug/CMR2.exe
-  #           CMR2Decomp/Debug/CMR2.pdb
-
   build:
     name: Build (MSVC 6.0)
     needs: [fetch-deps]
@@ -101,12 +82,6 @@ jobs:
           reccmp-project detect --what original   --search-path cmr2bin
           reccmp-project detect --what recompiled --search-path build
 
-      - name: Generate Accuracy Report
-        if: github.ref == 'refs/heads/main' # Only runs on main branch
-        shell: bash
-        run: |
-          reccmp-reccmp --target CMR2 --html index.html --json CMR2PROGRESS/summary.json
-
       - name: Compare Accuracy to main
         if: github.ref != 'refs/heads/main' # Only runs on pull requests
         shell: bash
@@ -117,7 +92,7 @@ jobs:
           curl -fLSs -o summary-old.json $RELEASE_URL/summary.json || echo "" >summary-old.json
 
           # Compare with current main
-          reccmp-reccmp --target CMR2 --diff summary-old.json || echo "Current master not found"
+          reccmp-reccmp --target CMR2 --html index.html --json CMR2PROGRESS/summary.json --diff summary-old.json || echo "Current master not found"
 
       - name: Test Exports
         shell: bash
@@ -136,7 +111,7 @@ jobs:
           reccmp-datacmp --target CMR2
 
       - name: Commit Accuracy Reports
-        if: github.ref == 'refs/heads/main' # Only runs on the 'main' branch
+        if: github.ref != 'refs/heads/main' # Only runs on the 'main' branch
         shell: bash
         run: |
           git config user.name github-actions

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ When running this from the root directory of this repository via `cmd.exe`, the 
 call "<msvc600_dir>/VC98/bin/cl.exe" CMR2Decomp/*.cpp /Fe"build/CMR2.exe" /O2 /DNDEBUG /Zi /MD /link user32.lib gdi32.lib /DEBUG /PDB:"build\CMR2.pdb" /SUBSYSTEM:WINDOWS
 ```
 
-# GitHub Workflows
+## GitHub Workflows
 
 However, when pushing to this repository it is being compiled with the help of a portable version of [MSVC6.0](https://github.com/itsmattkc/MSVC600). Which we understand is probably the closest compiler we'll get to what was originally used. As you can see from the [reccmp output](https://cmr2decomp.github.io/CMR2Decomp/) the accuracy is much better than when it was compiled with modern day compilers.


### PR DESCRIPTION
The accuracy report will now be updated on the PR so that we can lock down the main branch