### PR TITLE
Update FUN_004a78a0

### DIFF
--- a/CMR2Decomp/Graphics.cpp
+++ b/CMR2Decomp/Graphics.cpp
@@ -97,6 +97,7 @@ void CGraphics::FUN_004a78a0(unsigned int screenWidth, unsigned int screenHeight
     if (m_unk0x00520b7c == 0) {
         CSound::FUN_004a2b50(TRUE);
         FUN_004a5be0();
+        ReleaseDirect3D();
     }
 }
 
@@ -147,7 +148,29 @@ BOOL CGraphics::FUN_004a5be0(void) {
     return TRUE;
 }
 
+// FUNCTION: CMR2 0x004a8810
+BOOL CGraphics::ReleaseDirect3D(void)
+{
+    FUN_004b1de0();
+
+    if (m_pTextureManager->pD3D != NULL && m_pTextureManager->pD3D->Release() == 0)
+        m_pTextureManager->pD3D = NULL;
+    
+    m_pTextureManager->pD3D = NULL;
+    
+    if (m_pTextureManager->pDD != NULL && m_pTextureManager->pDD->Release() == 0)
+        m_pTextureManager->pDD = NULL;
+    
+    m_pTextureManager->pDD = NULL;
+    return TRUE;
+}
+
 // STUB: CMR2 0x004a5ba0
 void CGraphics::FUN_004a5ba0(void) {
+
+}
+
+// STUB: CMR2 0x004b1de0
+void CGraphics::FUN_004b1de0(void) {
 
 }

--- a/CMR2Decomp/Graphics.cpp
+++ b/CMR2Decomp/Graphics.cpp
@@ -1,6 +1,5 @@
 #include "Graphics.h"
 #include "GameInfo.h"
-#include "Input.h"
 #include "RegKey.h"
 #include "main.h"
 #include "Sound.h"
@@ -10,12 +9,13 @@ Graphics g_graphics;
 
 // GLOBAL: CMR2 0x00520b74
 Graphics *g_pGraphics = &g_graphics;
+D3DTextureManager *CGraphics::m_pTextureManager;
 
 char CGraphics::m_strSettingConfigurationToDefault[36] = "Setting configuration to defaults";
 
 BOOL CGraphics::m_unk0x00520b7c = TRUE;
-BOOL CGraphics::m_unk0x005a2734 = FALSE;
-char CGraphics::m_unk0x005a2738[256];
+void* CGraphics::m_unk0x0065fa2c;
+int CGraphics::m_unk0x0065fa28;
 
 // FUNCTION: CMR2 0x00405830
 bool CGraphics::InitializeDirectX(void) {
@@ -95,16 +95,59 @@ void CGraphics::SetDefaults(void) {
 // FUNCTION: CMR2 0x004a78a0
 void CGraphics::FUN_004a78a0(unsigned int screenWidth, unsigned int screenHeight, unsigned int colourDepth, unsigned int param4, unsigned int param5) {
     if (m_unk0x00520b7c == 0) {
-        FUN_004a2b50(TRUE);
+        CSound::FUN_004a2b50(TRUE);
+        FUN_004a5be0();
     }
 }
 
-// FUNCTION: CMR2 0x004a2b50
-void CGraphics::FUN_004a2b50(BOOL param1) {
-    CSound::FUN_004a2ac0();
-    if (param1 == 0) {
-        m_unk0x005a2734 = FALSE;
-        strcpy(m_unk0x005a2738, CMain::m_logFileBlankLine);
+// FUNCTION: CMR2 0x004a5be0
+BOOL CGraphics::FUN_004a5be0(void) {
+    int index, textureID, iVar4, iVar7;
+
+    m_pTextureManager->pDD->EvictManagedTextures();
+    m_unk0x0065fa2c = NULL;
+
+    index = 0;
+    textureID = 0;
+    do {
+        Texture* pTexture = m_pTextureManager->textureBuffer[index];
+        if (pTexture != NULL && pTexture->pSurface != NULL && textureID == pTexture->textureId) {
+            
+            if (pTexture->pSurface->Release() == 0) {
+                pTexture->pSurface = NULL;
+            }
+        }
+        
+        index++;
+        textureID++;
+    } while (index < 2048);
+
+    FUN_004a5ba0();
+    index = 0;
+
+    if (m_unk0x0065fa28 != 0) {
+        do {
+            iVar4 = 0x5f0;
+            iVar7 = 0x734;
+
+            do {
+                Texture* pTexture = m_pTextureManager->textureBuffer2[index];
+                if (pTexture != NULL) {
+                    IDirectDrawSurface7* pOther = pTexture->pSurface;
+                    if (pOther->Release() == 0) {
+                        pTexture->pSurface = NULL;
+                    }
+                }
+            } while (0x71f < iVar7);
+            
+            index++;
+        } while (index < m_unk0x0065fa28);
     }
+
+    return TRUE;
 }
 
+// STUB: CMR2 0x004a5ba0
+void CGraphics::FUN_004a5ba0(void) {
+
+}

--- a/CMR2Decomp/Graphics.cpp
+++ b/CMR2Decomp/Graphics.cpp
@@ -16,6 +16,7 @@ char CGraphics::m_strSettingConfigurationToDefault[36] = "Setting configuration 
 BOOL CGraphics::m_unk0x00520b7c = TRUE;
 void* CGraphics::m_unk0x0065fa2c;
 int CGraphics::m_unk0x0065fa28;
+int CGraphics::m_unk0x006dd890;
 
 // FUNCTION: CMR2 0x00405830
 bool CGraphics::InitializeDirectX(void) {
@@ -172,6 +173,7 @@ void CGraphics::FUN_004a5ba0(void) {
 
 // FUNCTION: CMR2 0x004b1de0
 void CGraphics::ReleaseVertexBuffers(void) {
+    int index = 99;
     if (m_pTextureManager->pVertexBuffer3 != NULL && m_pTextureManager->pVertexBuffer3->Release() == 0)
         m_pTextureManager->pVertexBuffer3 = NULL;
     
@@ -179,5 +181,15 @@ void CGraphics::ReleaseVertexBuffers(void) {
         m_pTextureManager->pVertexBuffer2 = NULL;
 
     if (m_pTextureManager->pVertexBuffer1 != NULL && m_pTextureManager->pVertexBuffer1->Release() == 0)
-        m_pTextureManager->pVertexBuffer1 = NULL;        
+        m_pTextureManager->pVertexBuffer1 = NULL;
+
+    // not sure if this loop is fully correct or not
+    do {
+        if (m_pTextureManager->pVertexBuffers[index] != NULL && m_pTextureManager->pVertexBuffers[index]->Release() == 0)
+            m_pTextureManager->pVertexBuffers[index] = NULL;
+
+        index--;
+    } while (index >= 0);
+
+    m_unk0x006dd890 = 0;
 }

--- a/CMR2Decomp/Graphics.cpp
+++ b/CMR2Decomp/Graphics.cpp
@@ -3,6 +3,7 @@
 #include "RegKey.h"
 #include "main.h"
 #include "Sound.h"
+#include <basetsd.h>
 
 // GLOBAL: CMR2 0x00660830
 Graphics g_graphics;
@@ -17,6 +18,7 @@ BOOL CGraphics::m_unk0x00520b7c = TRUE;
 void* CGraphics::m_unk0x0065fa2c;
 int CGraphics::m_unk0x0065fa28;
 int CGraphics::m_unk0x006dd890;
+int CGraphics::m_unk0x00663b1c;
 
 // FUNCTION: CMR2 0x00405830
 bool CGraphics::InitializeDirectX(void) {
@@ -101,6 +103,8 @@ void CGraphics::FUN_004a78a0(unsigned int screenWidth, unsigned int screenHeight
         ReleaseDirect3D();
         ReleaseSurfaces();
     }
+
+    FUN_004a8bd0(param4);
 }
 
 // FUNCTION: CMR2 0x004a5be0
@@ -220,4 +224,9 @@ void CGraphics::ReleaseSurfaces(void) {
     if (g_pGraphics->pDD7 != NULL && g_pGraphics->pDD7->Release() == 0) {
         g_pGraphics->pDD7 = NULL;
     }
+}
+
+// FUNCTION: CMR2 0x004a8bd0
+void CGraphics::FUN_004a8bd0(int param1) {
+    m_unk0x00663b1c = param1;
 }

--- a/CMR2Decomp/Graphics.cpp
+++ b/CMR2Decomp/Graphics.cpp
@@ -96,7 +96,7 @@ void CGraphics::SetDefaults(void) {
 void CGraphics::FUN_004a78a0(unsigned int screenWidth, unsigned int screenHeight, unsigned int colourDepth, unsigned int param4, unsigned int param5) {
     if (m_unk0x00520b7c == 0) {
         CSound::FUN_004a2b50(TRUE);
-        FUN_004a5be0();
+        FUN_004a5be0(); // TODO: UNFINISHED
         ReleaseDirect3D();
     }
 }
@@ -151,7 +151,7 @@ BOOL CGraphics::FUN_004a5be0(void) {
 // FUNCTION: CMR2 0x004a8810
 BOOL CGraphics::ReleaseDirect3D(void)
 {
-    FUN_004b1de0();
+    ReleaseVertexBuffers();
 
     if (m_pTextureManager->pD3D != NULL && m_pTextureManager->pD3D->Release() == 0)
         m_pTextureManager->pD3D = NULL;
@@ -170,7 +170,14 @@ void CGraphics::FUN_004a5ba0(void) {
 
 }
 
-// STUB: CMR2 0x004b1de0
-void CGraphics::FUN_004b1de0(void) {
+// FUNCTION: CMR2 0x004b1de0
+void CGraphics::ReleaseVertexBuffers(void) {
+    if (m_pTextureManager->pVertexBuffer3 != NULL && m_pTextureManager->pVertexBuffer3->Release() == 0)
+        m_pTextureManager->pVertexBuffer3 = NULL;
+    
+    if (m_pTextureManager->pVertexBuffer2 != NULL && m_pTextureManager->pVertexBuffer2->Release() == 0)
+        m_pTextureManager->pVertexBuffer2 = NULL;
 
+    if (m_pTextureManager->pVertexBuffer1 != NULL && m_pTextureManager->pVertexBuffer1->Release() == 0)
+        m_pTextureManager->pVertexBuffer1 = NULL;        
 }

--- a/CMR2Decomp/Graphics.cpp
+++ b/CMR2Decomp/Graphics.cpp
@@ -19,6 +19,7 @@ void* CGraphics::m_unk0x0065fa2c;
 int CGraphics::m_unk0x0065fa28;
 int CGraphics::m_unk0x006dd890;
 int CGraphics::m_unk0x00663b1c;
+int CGraphics::m_unk0x00663b24;
 
 // FUNCTION: CMR2 0x00405830
 bool CGraphics::InitializeDirectX(void) {
@@ -229,4 +230,9 @@ void CGraphics::ReleaseSurfaces(void) {
 // FUNCTION: CMR2 0x004a8bd0
 void CGraphics::FUN_004a8bd0(int param1) {
     m_unk0x00663b1c = param1;
+}
+
+// FUNCTION: CMR2 0x004a8d90
+void CGraphics::FUN_004a8d90(int param1) {
+    m_unk0x00663b24 = param1;
 }

--- a/CMR2Decomp/Graphics.cpp
+++ b/CMR2Decomp/Graphics.cpp
@@ -99,6 +99,7 @@ void CGraphics::FUN_004a78a0(unsigned int screenWidth, unsigned int screenHeight
         CSound::FUN_004a2b50(TRUE);
         FUN_004a5be0(); // TODO: UNFINISHED
         ReleaseDirect3D();
+        ReleaseSurfaces();
     }
 }
 
@@ -192,4 +193,31 @@ void CGraphics::ReleaseVertexBuffers(void) {
     } while (index >= 0);
 
     m_unk0x006dd890 = 0;
+}
+
+// FUNCTION: CMR2 0x004a8040
+void CGraphics::ReleaseSurfaces(void) {
+    if (g_pGraphics->pSurface3 != NULL && g_pGraphics->pSurface3->Release() == 0)
+        g_pGraphics->pSurface3 = NULL;
+
+    g_pGraphics->pSurface3 = NULL;
+
+    if (g_pGraphics->pSurface2 != NULL && g_pGraphics->pSurface2->Release() == 0)
+        g_pGraphics->pSurface2 = NULL;
+
+    g_pGraphics->pSurface2 = NULL;
+
+    if (g_pGraphics->pSurface != NULL && g_pGraphics->pSurface->Release() == 0)
+        g_pGraphics->pSurface = NULL;
+
+    g_pGraphics->pSurface = NULL;
+    
+    g_pGraphics->pDD7->SetCooperativeLevel(CMain::m_hWndList[CMain::m_hWndIx], DDSCL_NORMAL);
+    if (g_pGraphics->isFullscreen != 0) {
+        g_pGraphics->pDD7->RestoreDisplayMode();
+    }
+
+    if (g_pGraphics->pDD7 != NULL && g_pGraphics->pDD7->Release() == 0) {
+        g_pGraphics->pDD7 = NULL;
+    }
 }

--- a/CMR2Decomp/Graphics.h
+++ b/CMR2Decomp/Graphics.h
@@ -934,17 +934,17 @@ struct Graphics
 };
 
 struct D3DTextureManager {
-    IDirect3D7* pDD;                      // 0x0
-    IDirect3DDevice7* pD3D;               // 0x4
-    GUID* pDeviceGUID;                    // 0x8
-    DWORD field_0xc;                      // 0xc
-    DWORD field_0x10;                     // 0x10
-    DWORD field_0x14;                     // 0x14
-    BYTE field_0x18[0x320];                 // 0x18 - 0x337 (padding)
-    IDirect3DVertexBuffer7* pVertexBuffer1;  // 0x338 - 0x1800 verts
-    IDirect3DVertexBuffer7* pVertexBuffer2;  // 0x33c - 0x7080 verts
-    IDirect3DVertexBuffer7* pVertexBuffer3;  // 0x340 - 1 vert
-    BYTE field_0x344[0xc];                   // 0x344 - 0x34f (padding)
+    IDirect3D7* pDD;                              // 0x0
+    IDirect3DDevice7* pD3D;                       // 0x4
+    GUID* pDeviceGUID;                             // 0x8
+    DWORD field_0xc;                               // 0xc
+    DWORD field_0x10;                              // 0x10
+    DWORD field_0x14;                              // 0x14
+    IDirect3DVertexBuffer7* pVertexBuffers[200];   // 0x18 - 0x337
+    IDirect3DVertexBuffer7* pVertexBuffer1;        // 0x338
+    IDirect3DVertexBuffer7* pVertexBuffer2;        // 0x33c
+    IDirect3DVertexBuffer7* pVertexBuffer3;        // 0x340
+    BYTE field_0x344[0xc];                          // 0x344 - 0x34f
     void* textureInfo1;                  // 0x350 (TextureInfo*)
     void* textureInfo2;                  // 0x354 (TextureInfo*)
     void* textureInfo3;                  // 0x358 (TextureInfo*)
@@ -986,6 +986,9 @@ private:
 
     // GLOBAL: CMR2 0x0065fa28
     static int m_unk0x0065fa28;
+
+    // GLOBAL: CMR2 0x006dd890
+    static int m_unk0x006dd890;
 };
 
 #endif

--- a/CMR2Decomp/Graphics.h
+++ b/CMR2Decomp/Graphics.h
@@ -971,6 +971,7 @@ public:
     static BOOL ReleaseDirect3D(void);
     static void ReleaseVertexBuffers(void);
     static void ReleaseSurfaces(void);
+    static void FUN_004a8bd0(int param1);
 
 private:
     // GLOBAL: CMR2 0x0051615c
@@ -990,6 +991,9 @@ private:
 
     // GLOBAL: CMR2 0x006dd890
     static int m_unk0x006dd890;
+    
+    // GLOBAL: CMR2 0x00663b1c
+    static int m_unk0x00663b1c;
 };
 
 #endif

--- a/CMR2Decomp/Graphics.h
+++ b/CMR2Decomp/Graphics.h
@@ -934,13 +934,17 @@ struct Graphics
 };
 
 struct D3DTextureManager {
-    IDirect3D7* pDD;                     // 0x0
-    IDirect3DDevice7* pD3D;              // 0x4
-    GUID* pDeviceGUID;                   // 0x8
-    DWORD field_0xc;                     // 0xc
-    DWORD field_0x10;                    // 0x10
-    DWORD field_0x14;                    // 0x14
-    BYTE field_0x18[0x338];              // 0x18 - 0x34f (padding)
+    IDirect3D7* pDD;                      // 0x0
+    IDirect3DDevice7* pD3D;               // 0x4
+    GUID* pDeviceGUID;                    // 0x8
+    DWORD field_0xc;                      // 0xc
+    DWORD field_0x10;                     // 0x10
+    DWORD field_0x14;                     // 0x14
+    BYTE field_0x18[0x320];                 // 0x18 - 0x337 (padding)
+    IDirect3DVertexBuffer7* pVertexBuffer1;  // 0x338 - 0x1800 verts
+    IDirect3DVertexBuffer7* pVertexBuffer2;  // 0x33c - 0x7080 verts
+    IDirect3DVertexBuffer7* pVertexBuffer3;  // 0x340 - 1 vert
+    BYTE field_0x344[0xc];                   // 0x344 - 0x34f (padding)
     void* textureInfo1;                  // 0x350 (TextureInfo*)
     void* textureInfo2;                  // 0x354 (TextureInfo*)
     void* textureInfo3;                  // 0x358 (TextureInfo*)
@@ -965,7 +969,7 @@ public:
     static void FUN_004a5ba0(void);
     static BOOL FUN_004a5be0(void);
     static BOOL ReleaseDirect3D(void);
-    static void FUN_004b1de0(void);
+    static void ReleaseVertexBuffers(void);
 
 private:
     // GLOBAL: CMR2 0x0051615c

--- a/CMR2Decomp/Graphics.h
+++ b/CMR2Decomp/Graphics.h
@@ -298,7 +298,7 @@ struct Graphics
     unsigned char field287_0x131;
     unsigned char field288_0x132;
     unsigned char field289_0x133;
-    IDirectDrawSurface7 **pSurface;
+    IDirectDrawSurface7 *pSurface;
     unsigned char field291_0x138;
     unsigned char field292_0x139;
     unsigned char field293_0x13a;
@@ -593,7 +593,7 @@ struct Graphics
     unsigned char field582_0x261;
     unsigned char field583_0x262;
     unsigned char field584_0x263;
-    IDirectDrawSurface7 **pSurface2;
+    IDirectDrawSurface7 *pSurface2;
     unsigned char field586_0x268;
     unsigned char field587_0x269;
     unsigned char field588_0x26a;
@@ -890,7 +890,7 @@ struct Graphics
     unsigned char field879_0x391;
     unsigned char field880_0x392;
     unsigned char field881_0x393;
-    IDirectDrawSurface7 **pSurface3;
+    IDirectDrawSurface7 *pSurface3;
     unsigned char field883_0x398;
     unsigned char field884_0x399;
     unsigned char field885_0x39a;
@@ -970,6 +970,7 @@ public:
     static BOOL FUN_004a5be0(void);
     static BOOL ReleaseDirect3D(void);
     static void ReleaseVertexBuffers(void);
+    static void ReleaseSurfaces(void);
 
 private:
     // GLOBAL: CMR2 0x0051615c

--- a/CMR2Decomp/Graphics.h
+++ b/CMR2Decomp/Graphics.h
@@ -972,6 +972,7 @@ public:
     static void ReleaseVertexBuffers(void);
     static void ReleaseSurfaces(void);
     static void FUN_004a8bd0(int param1);
+    static void FUN_004a8d90(int param1);
 
 private:
     // GLOBAL: CMR2 0x0051615c
@@ -994,6 +995,9 @@ private:
     
     // GLOBAL: CMR2 0x00663b1c
     static int m_unk0x00663b1c;
+    
+    // GLOBAL: CMR2 0x00663b24
+    static int m_unk0x00663b24;    
 };
 
 #endif

--- a/CMR2Decomp/Graphics.h
+++ b/CMR2Decomp/Graphics.h
@@ -964,6 +964,8 @@ public:
     static void FUN_004a78a0(unsigned int screenWidth, unsigned int screenHeight, unsigned int colourDepth, unsigned int param4, unsigned int param5);
     static void FUN_004a5ba0(void);
     static BOOL FUN_004a5be0(void);
+    static BOOL ReleaseDirect3D(void);
+    static void FUN_004b1de0(void);
 
 private:
     // GLOBAL: CMR2 0x0051615c

--- a/CMR2Decomp/Graphics.h
+++ b/CMR2Decomp/Graphics.h
@@ -4,6 +4,8 @@
 #include <windows.h>
 #include "../third_party/dx7sdk-7001/include/d3d.h"
 
+#include "Texture.h"
+
 struct Graphics
 {
     unsigned int resX;
@@ -931,6 +933,25 @@ struct Graphics
     unsigned char field928_0x3cb;
 };
 
+struct D3DTextureManager {
+    IDirect3D7* pDD;                     // 0x0
+    IDirect3DDevice7* pD3D;              // 0x4
+    GUID* pDeviceGUID;                   // 0x8
+    DWORD field_0xc;                     // 0xc
+    DWORD field_0x10;                    // 0x10
+    DWORD field_0x14;                    // 0x14
+    BYTE field_0x18[0x338];              // 0x18 - 0x34f (padding)
+    void* textureInfo1;                  // 0x350 (TextureInfo*)
+    void* textureInfo2;                  // 0x354 (TextureInfo*)
+    void* textureInfo3;                  // 0x358 (TextureInfo*)
+    void* textureInfo4;                  // 0x35c (TextureInfo*)
+    void* textureInfo5;                  // 0x360 (TextureInfo*)
+    DDPIXELFORMAT ddpfZBuffer;           // 0x364
+    Texture* textureBuffer[2048];        // 0x384
+    Texture* textureBuffer2[20];            // 0x2384
+    BYTE field_0x23d4[0x94];             // 0x23d4 - 0x2467 (padding)
+};
+
 extern Graphics *g_pGraphics;
 
 // GLOBAL: CMR2 0x005114a8
@@ -940,21 +961,25 @@ class CGraphics {
 public:
     static bool InitializeDirectX(void);
     static void SetDefaults(void);
-    static void FUN_004a2b50(BOOL param1);
     static void FUN_004a78a0(unsigned int screenWidth, unsigned int screenHeight, unsigned int colourDepth, unsigned int param4, unsigned int param5);
+    static void FUN_004a5ba0(void);
+    static BOOL FUN_004a5be0(void);
 
 private:
     // GLOBAL: CMR2 0x0051615c
     static char m_strSettingConfigurationToDefault[36];
 
+    // GLOBAL: CMR2 0x00520b78
+    static D3DTextureManager* m_pTextureManager;
+
     // GLOBAL: CMR2 0x00520b7c
     static BOOL m_unk0x00520b7c;
 
-    // GLOBAL: CMR2 0x005a2734
-    static BOOL m_unk0x005a2734;
+    // GLOBAL: CMR2 0x0065fa2c
+    static void* m_unk0x0065fa2c;
 
-    // GLOBAL: CMR2 0x005a2738
-    static char m_unk0x005a2738[256];
+    // GLOBAL: CMR2 0x0065fa28
+    static int m_unk0x0065fa28;
 };
 
 #endif

--- a/CMR2Decomp/Sound.cpp
+++ b/CMR2Decomp/Sound.cpp
@@ -1,4 +1,5 @@
 #include "Sound.h"
+#include "main.h"
 
 BOOL CSound::m_unk0x005a2728;
 BOOL CSound::m_unk0x005a272c;
@@ -7,6 +8,17 @@ MMIOData *CSound::m_pMMIO;
 IDirectSoundBuffer* CSound::m_pDirectSoundBuffer;
 HACMSTREAM CSound::m_unk0x00816a7c;
 BOOL CSound::m_unk0x005a2720;
+BOOL CSound::m_unk0x005a2734 = FALSE;
+char CSound::m_unk0x005a2738[256];
+
+// FUNCTION: CMR2 0x004a2b50
+void CSound::FUN_004a2b50(BOOL param1) {
+    FUN_004a2ac0();
+    if (param1 == 0) {
+        m_unk0x005a2734 = FALSE;
+        strcpy(m_unk0x005a2738, CMain::m_logFileBlankLine);
+    }
+}
 
 // FUNCTION: CMR2 0x004a2ac0
 BOOL __fastcall CSound::FUN_004a2ac0(void) {

--- a/CMR2Decomp/Sound.h
+++ b/CMR2Decomp/Sound.h
@@ -16,11 +16,13 @@ struct MMIOData {
 class CSound {
 public:
     static BOOL __fastcall FUN_004a2ac0(void);
+    static void FUN_004a2b50(BOOL param1);
     static bool FUN_004bd230(void);
     static HRESULT StopDirectSoundBuffer(void);
     static bool FUN_004a3250(HRESULT param1);
     static MMRESULT __fastcall CloseMMIO(MMIOData* hhmio);
     static void __fastcall CloseAndCleanupMMIO(MMIOData* pMMIO);
+    
 
     // GLOBAL: CMR2 0x005a23e8
     static MMIOData *m_pMMIO;
@@ -36,6 +38,12 @@ public:
 
     // GLOBAL: CMR2 0x005a2730
     static BOOL m_unk0x005a2730;
+
+    // GLOBAL: CMR2 0x005a2734
+    static BOOL m_unk0x005a2734;
+
+    // GLOBAL: CMR2 0x005a2738
+    static char m_unk0x005a2738[256];    
 
     // GLOBAL: CMR2 0x005a2854
     static IDirectSoundBuffer* m_pDirectSoundBuffer;

--- a/CMR2Decomp/Texture.h
+++ b/CMR2Decomp/Texture.h
@@ -2,8 +2,16 @@
 #define _TEXTURE_H
 
 #include "GenericFileLoader.h"
+#include "../third_party/dx7sdk-7001/include/ddraw.h"
 
-struct Texture {};
+struct Texture {
+    USHORT                  textureId;
+    BYTE                    field_0x2[134];
+    BYTE                    field_0x134[140];
+    IDirectDrawSurface7*    pSurface;
+    BYTE                    field_288[612];
+    void*                   buffer;
+};
 
 class CTexture {
 public:

--- a/CMR2Decomp/temp.h
+++ b/CMR2Decomp/temp.h
@@ -1,0 +1,15 @@
+typedef struct IDirect3DVertexBuffer7Vtbl {
+    void* QueryInterface;
+    void* AddRef;
+    void* Release;
+    void* Lock;
+    void* Unlock;
+    void* ProcessVertices;
+    void* GetVertexBufferDesc;
+    void* Optimize;
+    void* ProcessVerticesStrided;
+} IDirect3DVertexBuffer7Vtbl;
+
+typedef struct IDirect3DVertexBuffer7 {
+    IDirect3DVertexBuffer7Vtbl* lpVtbl;
+} IDirect3DVertexBuffer7;


### PR DESCRIPTION
Further additions to `FUN_004a78a0` (0x004a78a0):

[Add CGraphics::ReleaseDirect3D (0x004a8810)](https://github.com/CMR2Decomp/CMR2Decomp/commit/328019f0d23372f198ff0c3d97a42e20bf19788b)
[Add CGraphics::ReleaseVertexBuffers (0x004b1de0)](https://github.com/CMR2Decomp/CMR2Decomp/commit/c8adec75b6f5fc317bd332934c5aa7cd0c99a1a2)
[Add CGraphics::ReleaseSurfaces (0x004a8040)](https://github.com/CMR2Decomp/CMR2Decomp/commit/601eaf7fc0b7fb3563ddae010b1cd1e2836c6b00)
[Add CGraphics::FUN_004a8bd0 (0x004a8bd0)](https://github.com/CMR2Decomp/CMR2Decomp/commit/86581d7feb4465b8a5cd387f22d496b873cf6d43)
[Add CGraphics::FUN_004a8d90 (0x004a8d90)](https://github.com/CMR2Decomp/CMR2Decomp/commit/ae2baa91e81517bba464215167ac43bcef1e1bac)